### PR TITLE
Fixes #37

### DIFF
--- a/R/qmd.R
+++ b/R/qmd.R
@@ -5,7 +5,11 @@ url_db_from_package_qmd_vignettes <- function(dir) {
   # in `url_db_from_package_rmd_vignettes()`.
   qfiles <- grep("[.]qmd$", docs, value = TRUE)
   for (qfile in qfiles) {
-    qpath <- asNamespace("tools")$.file_path_relative_to_dir(qfile, dir)
+    # normalizePath() so `qfile` and `dir` use the same separator
+    qpath <- asNamespace("tools")$.file_path_relative_to_dir(
+      normalizePath(qfile),
+      dir
+    )
     qurls <- urls_from_quarto_qmd_file(qfile)
     urls <- c(urls, qurls)
     path <- c(path, rep.int(qpath, length(qurls)))

--- a/R/rmd.R
+++ b/R/rmd.R
@@ -5,7 +5,11 @@ url_db_from_package_rmd_vignettes <- function(dir) {
   # in `url_db_from_package_qmd_vignettes()`.
   rfiles <- grep("[.][Rr]md$", docs, value = TRUE)
   for (rfile in rfiles) {
-    rpath <- asNamespace("tools")$.file_path_relative_to_dir(rfile, dir)
+    # normalizePath() so `rfile` and `dir` use the same separator
+    rpath <- asNamespace("tools")$.file_path_relative_to_dir(
+      normalizePath(rfile),
+      dir
+    )
     rurls <- urls_from_pandoc_md_file(rfile)
     urls <- c(urls, rurls)
     path <- c(path, rep.int(rpath, length(rurls)))


### PR DESCRIPTION
I was getting an error like @rempsyc when calling `urlchecker::url_check()` on Windows 11, where the absolute path to a vignette file was being prepended with the absolute path to the package directory, except using backslashes:

```
Error in file(con, "r") : cannot open the connection
In addition: Warning message:
In file(con, "r") :
  cannot open file 'C:\Users\derek\Documents\ipumsr/C:/Users/derek/Documents/ipumsr/vignettes/ipums-bigdata.Rmd': Invalid argument
```

Claude Code helped me identify the source of this error and a simple fix:

> Look at rmd.R:
>
>  rpath <- asNamespace("tools")$.file_path_relative_to_dir(rfile, dir)
>
>  dir comes from normalizePath(path) in url_check(), which on Windows produces backslashes:
>  C:\Users\derek\Documents\ipumsr
>
>  But rfile comes from tools::pkgVignettes(dir = dir)$docs, which can return forward slashes:
>  C:/Users/derek/Documents/ipumsr/vignettes/ipums-bigdata.Rmd
>
>  .file_path_relative_to_dir tries to strip the dir prefix from rfile, but the slashes don't match, so it returns the absolute path unchanged. Then the print method does file.path(root, absolute_path) and you get the doubled path.
>
>  The fix is to normalize rfile so both paths use the same separator:
>
>  rpath <- asNamespace("tools")$.file_path_relative_to_dir(normalizePath(rfile), dir)
>
>  That's it. One normalizePath() call wrapping rfile. This ensures both arguments have consistent Windows backslashes, so the prefix-stripping works correctly and produces a proper relative path like vignettes/ipums-bigdata.Rmd.

I confirmed that this fixes the issue in my case.